### PR TITLE
Fix runtime pipe

### DIFF
--- a/src/app/pipes/runtime/runtime.pipe.spec.ts
+++ b/src/app/pipes/runtime/runtime.pipe.spec.ts
@@ -16,5 +16,10 @@ describe('RuntimePipe', () => {
       const pipe = new RuntimePipe();
       expect(pipe.transform(85)).toEqual('1h25');
     });
+
+    it('should display 0h05 when 5 given', () => {
+      const pipe = new RuntimePipe();
+      expect(pipe.transform(5)).toEqual('0h05');
+    });
   });
 });

--- a/src/app/pipes/runtime/runtime.pipe.ts
+++ b/src/app/pipes/runtime/runtime.pipe.ts
@@ -11,6 +11,6 @@ export class RuntimePipe implements PipeTransform {
    * @param value Number of minutes
    */
   transform(minutes: number): string {
-    return minutes ? `${Math.floor(minutes / 60)}h${minutes % 60}` : '0h00';
+    return minutes ? `${Math.floor(minutes / 60)}h${(minutes % 60).toString().padStart(2, '0')}` : '0h00';
   }
 }


### PR DESCRIPTION
# Changelog

## Fix

* RuntimePipe: display minutes on two digits even when the number of minutes is between 0 and 9